### PR TITLE
Update PreBuild.sh

### DIFF
--- a/src/AutoMapper/ApiCompat/PreBuild.sh
+++ b/src/AutoMapper/ApiCompat/PreBuild.sh
@@ -12,4 +12,4 @@ oldVersion="$oldVersion.0.0"
 echo $oldVersion
 rm -rf ../LastMajorVersionBinary
 curl https://globalcdn.nuget.org/packages/automapper.$oldVersion.nupkg --create-dirs -o ../LastMajorVersionBinary/automapper.$oldVersion.nupkg
-unzip -j ../LastMajorVersionBinary/automapper.$oldVersion.nupkg lib/netstandard2.1/AutoMapper.dll -d ../LastMajorVersionBinary
+unzip -j ../LastMajorVersionBinary/automapper.$oldVersion.nupkg lib/net*.0/AutoMapper.dll -d ../LastMajorVersionBinary


### PR DESCRIPTION
The PreBuild script is failing on linux as AutoMapper.dll is no longer in .netstandard2.1 and instead it is is .net8.0